### PR TITLE
ci: store and use storybook build as artifact

### DIFF
--- a/.github/actions/run-storybook/action.yml
+++ b/.github/actions/run-storybook/action.yml
@@ -3,6 +3,10 @@
 
 name: Run Storybook
 description: Start server and run Storybook for Storybook tests
+inputs:
+  artifactName:
+    required: true
+    description: Artifact name of the Storybook build
 
 runs:
   using: composite
@@ -11,7 +15,7 @@ runs:
       id: download
       uses: actions/download-artifact@v3
       with:
-        name: artifact--storybook-build
+        name: ${{ inputs.artifactName }}
     - name: Run storybook
       uses: Eun/http-server-action@v1
       with:

--- a/.github/actions/run-storybook/action.yml
+++ b/.github/actions/run-storybook/action.yml
@@ -1,0 +1,19 @@
+# this is composite workflow that gets the repo ready for actions
+# for docs how composite workflows work see https://wallis.dev/blog/composite-github-actions
+
+name: Run Storybook
+description: Start server and run Storybook for Storybook tests
+
+runs:
+  using: composite
+  steps:
+    - name: Download Storybook build artifact
+      id: download
+      uses: actions/download-artifact@v3
+      with:
+        name: artifact--storybook-build
+    - name: Run storybook
+      uses: Eun/http-server-action@v1
+      with:
+        directory: ${{ steps.download.outputs.download-path }}
+        port: 6006

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -22,6 +22,9 @@ on:
     paths:
       - "**/CHANGELOG.md" # only changesets releases touch changelogs
 
+env:
+  ARTIFACT_NAME: artifact--storybook-build
+
 jobs:
   build-storybook:
     runs-on: ubuntu-latest
@@ -33,7 +36,7 @@ jobs:
       - name: Upload Storybook build as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: artifact--storybook-build
+          name: ${{ env.ARTIFACT_NAME }}
           path: "./storybook/public"
           retention-days: 1
 
@@ -47,6 +50,8 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright
       - uses: ./.github/actions/run-storybook
+        with:
+          artifactName: ${{ env.ARTIFACT_NAME }}
       - name: Storybook tests (1/3)
         run: yarn test:storybook --shard 1/3
 
@@ -60,6 +65,8 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright
       - uses: ./.github/actions/run-storybook
+        with:
+          artifactName: ${{ env.ARTIFACT_NAME }}
       - name: Storybook tests (2/3)
         run: yarn test:storybook --shard 2/3
 
@@ -73,6 +80,8 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright
       - uses: ./.github/actions/run-storybook
+        with:
+          artifactName: ${{ env.ARTIFACT_NAME }}
       - name: Storybook tests (3/3)
         run: yarn test:storybook --shard 3/3
 
@@ -91,7 +100,7 @@ jobs:
         id: download
         uses: actions/download-artifact@v3
         with:
-          name: artifact--storybook-build
+          name: ${{ env.ARTIFACT_NAME }}
       - id: publishChromatic
         name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/test-stories.yaml
+++ b/.github/workflows/test-stories.yaml
@@ -23,7 +23,61 @@ on:
       - "**/CHANGELOG.md" # only changesets releases touch changelogs
 
 jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - run: yarn storybook:build --webpack-stats-json
+      - name: Upload Storybook build as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact--storybook-build
+          path: "./storybook/public"
+          retention-days: 1
+
+  storybook-tests-1:
+    name: "test-storybook"
+    needs: build-storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/playwright
+      - uses: ./.github/actions/run-storybook
+      - name: Storybook tests (1/3)
+        run: yarn test:storybook --shard 1/3
+
+  storybook-tests-2:
+    name: "test-storybook"
+    needs: build-storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/playwright
+      - uses: ./.github/actions/run-storybook
+      - name: Storybook tests (2/3)
+        run: yarn test:storybook --shard 2/3
+
+  storybook-tests-3:
+    name: "test-storybook"
+    needs: build-storybook
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/playwright
+      - uses: ./.github/actions/run-storybook
+      - name: Storybook tests (3/3)
+        run: yarn test:storybook --shard 3/3
+
   chromatic:
+    needs: build-storybook
     if: github.head_ref != 'changeset-release/main' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
@@ -33,17 +87,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
-      - name: Build Storybook
-        run: |
-          yarn storybook:build --webpack-stats-json
+      - name: Download Storybook build artifact
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact--storybook-build
       - id: publishChromatic
         name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
           token: ${{ github.token }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: "./storybook/public"
+          storybookBuildDir: ${{ steps.download.outputs.download-path }}
           onlyChanged: "!(main)"
           externals: |
             [
@@ -71,39 +126,3 @@ jobs:
           commitSha: ${{ env.COMMIT_SHA }}
           commitMessage: ${{ steps.getCommitMessage.outputs.commitMessage }}
           storybookUrl: ${{ needs.chromatic.outputs.storybookUrl }}
-
-  storybook-tests-1:
-    name: "test-storybook"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: chromatic
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/playwright
-      - name: Storybook tests (1/3)
-        run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 1/3
-
-  storybook-tests-2:
-    name: "test-storybook"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: chromatic
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/playwright
-      - name: Storybook tests (2/3)
-        run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 2/3
-
-  storybook-tests-3:
-    name: "test-storybook"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: chromatic
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/playwright
-      - name: Storybook tests (3/3)
-        run: yarn ci:test:storybook --url ${{ needs.chromatic.outputs.storybookUrl }} --shard 3/3

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "storybook:clean": "rm -rf storybook/public",
     "storybook:build": "storybook build -c storybook -o storybook/public --docs",
     "test:storybook": "STORIES=ignoreBrandMoment test-storybook --config-dir storybook",
-    "ci:test:storybook": "yarn test:storybook --no-index-json",
     "jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --no-cache",
     "lint": "yarn lint:ts --max-warnings=0 && yarn lint:format && yarn lint:styles",
     "lint:ts": "yarn eslint . -c .eslintrc.js --ext .ts,.tsx",


### PR DESCRIPTION
## What and why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Build storybook and upload it as an artifact, then download the artifact for all storybook tests and chromatic.
This allows us to run chromatic and storybook tests in parallel, instead of having the storybook tests wait for chromatic.

Side benefit: In a private repo, we cannot access Chromatic's uploaded storybook, therefore building it in the workflow allows us to keep it private.
