### PR TITLE
fix:  FilterMultiSelect margin-inline for chevron

### DIFF
--- a/.changeset/gentle-queens-jump.md
+++ b/.changeset/gentle-queens-jump.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": patch
+---
+
+use margin-inline so that icon spacing swaps in rtl

--- a/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.module.scss
@@ -10,5 +10,5 @@
 }
 
 .icon {
-  margin-left: $spacing-xs;
+  margin-inline-start: $spacing-xs;
 }


### PR DESCRIPTION
## Why
This PR adds margin-inline so that the spacing swaps sides in rtl.


## What
Before
<img width="239" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/6e33ae08-2320-456a-87ee-e9e37b842cac">

After
<img width="243" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/3f85409a-177a-4ec6-b321-93e201b914ff">
