### PR TITLE
Fix checkbox focus on table header row

### DIFF
--- a/.changeset/shy-steaks-cough.md
+++ b/.changeset/shy-steaks-cough.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-table": patch
+---
+
+fix checkbox focus on table header row

--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -70,7 +70,6 @@ $row-height-data-variant: 48px;
 .headerRowCell .headerRowCellTooltip {
   display: flex;
   align-items: stretch;
-  overflow: hidden;
 }
 
 .headerRowCellButton {

--- a/draft-packages/table/KaizenDraft/Table/Table.module.scss
+++ b/draft-packages/table/KaizenDraft/Table/Table.module.scss
@@ -72,6 +72,11 @@ $row-height-data-variant: 48px;
   align-items: stretch;
 }
 
+// overflow has to be set at this level as well as on the heading for some reason ¯\_(ツ)_/¯
+.headerRowCell.headerRowCellNoWrap .headerRowCellTooltip {
+  overflow: hidden;
+}
+
 .headerRowCellButton {
   @include button-reset;
 


### PR DESCRIPTION
## Why
<!-- Why have you created this PR? - Is it a new feature, or a bug fix? Or something else? -->
<!-- Reference any relevant Jira tickets so your reviewer can find more context if needed. -->
<!-- Fixing a GitHub issue? Add "Fixes [issue URL]". -->

Focus for the checkbox was being cut off


## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->

- removed overflow hidden to correctly show the checkbox focus

Before
<img width="355" alt="Screenshot 2023-08-29 at 2 27 33 pm" src="https://github.com/cultureamp/kaizen-legacy/assets/12579379/38d9d020-a787-4b05-b4ba-af550ac9ed2d">

After
![Screenshot 2023-09-01 at 1 32 06 pm](https://github.com/cultureamp/kaizen-legacy/assets/12579379/273d8375-a867-49cb-9155-b99819beac83)

