### PR TITLE
fix: DateRangePicker text align right in rtl

### DIFF
--- a/.changeset/strange-plums-complain.md
+++ b/.changeset/strange-plums-complain.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/date-picker": patch
+---
+
+align text right for rtl

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
@@ -58,6 +58,10 @@ $placeholder-opacity: 0.7;
     border-color: rgba($color-gray-500-rgb, 0.7);
   }
 
+  [dir="rtl"] & {
+    text-align: right;
+  }
+
   .value {
     padding-right: $button-base-padding-horizontal;
     padding-left: 1.75rem;

--- a/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
+++ b/packages/date-picker/src/DateRangePicker/DateRangePicker.module.scss
@@ -34,6 +34,10 @@ $placeholder-opacity: 0.7;
   margin-top: $spacing-6;
   padding: 0 $button-base-padding-horizontal;
 
+  [dir="rtl"] & {
+    text-align: right;
+  }
+
   &:focus-visible:not([disabled]),
   &:hover:not([disabled]) {
     background-color: $color-gray-200;
@@ -56,10 +60,6 @@ $placeholder-opacity: 0.7;
     opacity: $disabled-opacity;
     color: rgba($color-purple-800-rgb, $placeholder-opacity);
     border-color: rgba($color-gray-500-rgb, 0.7);
-  }
-
-  [dir="rtl"] & {
-    text-align: right;
   }
 
   .value {


### PR DESCRIPTION
## Why
This PR sets the text-align to be right for rtl.

If a container is very small it did not align the text to correct side in rtl.

Fixes REP-591.

## What
Before
<img width="274" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/005a5870-65c5-46d4-bb25-4eca4a16e2c3">

After
<img width="271" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/a3ea81e0-74eb-4fac-a78a-b8456641635f">

