### PR TITLE
fix: add classNameOverride to MultiSelectOption

### DIFF
--- a/.changeset/pink-ghosts-grow.md
+++ b/.changeset/pink-ghosts-grow.md
@@ -2,4 +2,4 @@
 "@kaizen/select": minor
 ---
 
-add content-box to icon so that it displays correctly in Murmur
+Add classNameOverride to MultiSelectOption.

--- a/.changeset/pink-ghosts-grow.md
+++ b/.changeset/pink-ghosts-grow.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": minor
+---
+
+add content-box to icon so that it displays correctly in Murmur

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -12,6 +12,7 @@ $iconAndBadgeHeight: $spacing-md;
   border: $border-solid-border-width $border-solid-border-style;
   border-color: $color-gray-500;
   border-radius: $border-solid-border-radius;
+  box-sizing: content-box; // Required to overwrite box-sizing in Murmur.
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -12,7 +12,6 @@ $iconAndBadgeHeight: $spacing-md;
   border: $border-solid-border-width $border-solid-border-style;
   border-color: $color-gray-500;
   border-radius: $border-solid-border-radius;
-  box-sizing: content-box; // Required to overwrite border-box in Murmur.
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.module.scss
@@ -12,7 +12,7 @@ $iconAndBadgeHeight: $spacing-md;
   border: $border-solid-border-width $border-solid-border-style;
   border-color: $color-gray-500;
   border-radius: $border-solid-border-radius;
-  box-sizing: content-box; // Required to overwrite box-sizing in Murmur.
+  box-sizing: content-box; // Required to overwrite border-box in Murmur.
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
@@ -1,11 +1,10 @@
-import React, { useMemo, HTMLAttributes } from "react"
+import React, { useMemo } from "react"
 import { useFocusRing } from "@react-aria/focus"
 import { useOption } from "@react-aria/listbox"
 import { mergeProps } from "@react-aria/utils"
 import classnames from "classnames"
 import { v4 } from "uuid"
 import { VisuallyHidden } from "@kaizen/a11y"
-import { OverrideClassName } from "@kaizen/component-base"
 import { Icon } from "@kaizen/component-library"
 import check from "@kaizen/component-library/icons/check.icon.svg"
 import { Badge } from "@kaizen/draft-badge"
@@ -13,8 +12,8 @@ import { MultiSelectItem } from "../../../types"
 import { useSelectionContext } from "../../provider"
 import styles from "./MultiSelectOption.module.scss"
 
-export interface MultiSelectOptionProps
-  extends OverrideClassName<HTMLAttributes<HTMLSpanElement>> {
+export interface MultiSelectOptionProps {
+  classNameOverride?: string
   item: MultiSelectItem
 }
 

--- a/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
+++ b/packages/select/src/FilterMultiSelect/components/MultiSelectOption/MultiSelectOption.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from "react"
+import React, { useMemo, HTMLAttributes } from "react"
 import { useFocusRing } from "@react-aria/focus"
 import { useOption } from "@react-aria/listbox"
 import { mergeProps } from "@react-aria/utils"
 import classnames from "classnames"
 import { v4 } from "uuid"
 import { VisuallyHidden } from "@kaizen/a11y"
+import { OverrideClassName } from "@kaizen/component-base"
 import { Icon } from "@kaizen/component-library"
 import check from "@kaizen/component-library/icons/check.icon.svg"
 import { Badge } from "@kaizen/draft-badge"
@@ -12,11 +13,13 @@ import { MultiSelectItem } from "../../../types"
 import { useSelectionContext } from "../../provider"
 import styles from "./MultiSelectOption.module.scss"
 
-export interface MultiSelectOptionProps {
+export interface MultiSelectOptionProps
+  extends OverrideClassName<HTMLAttributes<HTMLSpanElement>> {
   item: MultiSelectItem
 }
 
 export const MultiSelectOption = ({
+  classNameOverride,
   item,
 }: MultiSelectOptionProps): JSX.Element => {
   const { selectionState: state } = useSelectionContext()
@@ -39,6 +42,7 @@ export const MultiSelectOption = ({
       ref={ref}
       className={classnames(
         styles.option,
+        classNameOverride,
         isSelected && styles.isSelected,
         isFocusVisible && styles.isFocusVisible,
         isDisabled && styles.isDisabled


### PR DESCRIPTION
## Why
This PR adds classNameOverride to the MultiSelectOption.

In Murmur the icon was not displaying correctly due to the reset.scss file using `box-sizing: border-box;` adding `box-sizing: content-box;` to the icon resolves this issue in Murmur.

With classNameOverride added I can now add a Tailwind `box-content` class.

Fixes REP-597.

## What
Before
<img width="273" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/045100d4-cf26-4e8d-b4ca-77a758ea03a1">

After
<img width="274" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/648599ec-1c4f-4e3e-9810-6eb1b31fd02e">
