### PR TITLE
fix(TimeField): align label spacing and disabled with DatePicker

### DIFF
--- a/.changeset/fresh-keys-glow.md
+++ b/.changeset/fresh-keys-glow.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/date-picker": patch
+---
+
+Align spacing and disabled state with DatePicker

--- a/packages/date-picker/src/TimeField/TimeField.module.scss
+++ b/packages/date-picker/src/TimeField/TimeField.module.scss
@@ -33,6 +33,7 @@ $story-className--timefield-focus: ":global(.story__timefield-focus)";
   line-height: $typography-paragraph-body-line-height;
   padding: 0 $spacing-sm;
   height: $input-height;
+  margin-top: $spacing-6;
   width: 100%;
   box-sizing: border-box;
 

--- a/packages/date-picker/src/TimeField/TimeField.module.scss
+++ b/packages/date-picker/src/TimeField/TimeField.module.scss
@@ -22,6 +22,10 @@ $story-className--timefield-focus: ":global(.story__timefield-focus)";
   color: $color-purple-800;
 }
 
+.heading {
+  margin-bottom: $spacing-6;
+}
+
 .input {
   display: inline-flex;
   align-items: center;
@@ -33,7 +37,6 @@ $story-className--timefield-focus: ":global(.story__timefield-focus)";
   line-height: $typography-paragraph-body-line-height;
   padding: 0 $spacing-sm;
   height: $input-height;
-  margin-top: $spacing-6;
   width: 100%;
   box-sizing: border-box;
 

--- a/packages/date-picker/src/TimeField/TimeField.tsx
+++ b/packages/date-picker/src/TimeField/TimeField.tsx
@@ -97,7 +97,12 @@ const TimeFieldComponent = ({
   )
   return (
     <div className={classNameOverride}>
-      <Heading tag="div" variant="heading-6" {...labelProps}>
+      <Heading
+        tag="div"
+        variant="heading-6"
+        {...labelProps}
+        classNameOverride={state.isDisabled ? styles.isDisabled : ""}
+      >
         {label}
       </Heading>
       <div className={styles.wrapper}>

--- a/packages/date-picker/src/TimeField/TimeField.tsx
+++ b/packages/date-picker/src/TimeField/TimeField.tsx
@@ -101,7 +101,7 @@ const TimeFieldComponent = ({
         tag="div"
         variant="heading-6"
         {...labelProps}
-        classNameOverride={state.isDisabled ? styles.isDisabled : ""}
+        classNameOverride={classnames(state.isDisabled && styles.isDisabled)}
       >
         {label}
       </Heading>

--- a/packages/date-picker/src/TimeField/TimeField.tsx
+++ b/packages/date-picker/src/TimeField/TimeField.tsx
@@ -101,7 +101,10 @@ const TimeFieldComponent = ({
         tag="div"
         variant="heading-6"
         {...labelProps}
-        classNameOverride={classnames(state.isDisabled && styles.isDisabled)}
+        classNameOverride={classnames(
+          styles.heading,
+          state.isDisabled && styles.isDisabled
+        )}
       >
         {label}
       </Heading>


### PR DESCRIPTION
## Why
TimeField Label and Disabled state were not aligned with DatePicker


## What
Before 
<img width="535" alt="Screenshot 2023-09-06 at 11 13 17 am" src="https://github.com/cultureamp/kaizen-legacy/assets/12579379/15687efe-24c6-457a-8077-6e26d72ae0db">


After 
<img width="530" alt="Screenshot 2023-09-06 at 11 12 56 am" src="https://github.com/cultureamp/kaizen-legacy/assets/12579379/f9287243-08c8-460c-be77-261e4214b9fa">
<img width="1138" alt="Screenshot 2023-09-06 at 11 58 36 am" src="https://github.com/cultureamp/kaizen-legacy/assets/12579379/965eba4e-be22-4975-97a7-1dfdcd5f91d5">


