### PR TITLE
feat: set disabled prop on Select label.

### DIFF
--- a/.changeset/nervous-humans-kneel.md
+++ b/.changeset/nervous-humans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": patch
+---
+
+fix Select label font colour when disabled

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -161,7 +161,7 @@ export const Select = ({
           classNameOverride
         )}
       >
-        <Label {...labelProps} reversed={isReversed}>
+        <Label {...labelProps} reversed={isReversed} disabled={isDisabled}>
           {label}
         </Label>
         <HiddenSelect


### PR DESCRIPTION
## Why
When the `Select` component is disabled, the `label` for the component doesn't change colour. This PR aims to fix that.

## What
Screenshot of how it looks now: 
<img width="408" alt="Screenshot 2023-09-08 at 1 01 31 pm" src="https://github.com/cultureamp/kaizen-legacy/assets/4371940/97eb3ae0-227b-4b4b-9c1e-ddb2297094be">
