### PR TITLE
chore(storybook): remove classNameOverride global arg and remove undefined from controls

### DIFF
--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -54,6 +54,7 @@ const config = {
     reactDocgenTypescriptOptions: {
       skipChildrenPropWithoutDoc: false,
       shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
       propFilter: (prop): boolean => {
         const isHTMLElementProp =
           prop.parent?.fileName.includes("node_modules/@types/react") ?? false

--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -90,13 +90,6 @@ const preview = {
   },
   globalTypes,
   decorators,
-  argTypes: {
-    classNameOverride: {
-      type: "string",
-      description:
-        "Add extra classnames to the component. Try out some Tailwind classes (eg. `!mb-48`) to see!",
-    },
-  },
 } satisfies Preview
 
 export default preview


### PR DESCRIPTION
## Why

[KDS-1776](https://cultureamp.atlassian.net/jira/software/projects/KDS/boards/289?selectedIssue=KDS-1776)

Readers are confused.

## What
<!-- What do your changes do? How do they change/fix the current behavior? -->
<!-- Add screenshots, GIFs or videos to illustrate the changes.  -->
Remove `classNameOverride` global config which added it to every component's Storybook controls - even when the component didn't have the prop.

Also removed `undefined` for optional props in Storybook controls.

[KDS-1776]: https://cultureamp.atlassian.net/browse/KDS-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ