### PR TITLE
fix(Select): Select chevron up/down 20x20 width fix

### DIFF
--- a/.changeset/tricky-coats-judge.md
+++ b/.changeset/tricky-coats-judge.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": minor
+---
+
+fix: add flex-shrink 0 so that the chevron up/down icon has the correct 20x20 width

--- a/.changeset/tricky-coats-judge.md
+++ b/.changeset/tricky-coats-judge.md
@@ -1,5 +1,5 @@
 ---
-"@kaizen/select": minor
+"@kaizen/select": patch
 ---
 
 fix: add flex-shrink 0 so that the chevron up/down icon has the correct 20x20 width

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -5,9 +5,9 @@
 @import "./variables";
 
 .icon {
+  color: $color-gray-500;
   flex-shrink: 0;
   margin-left: $spacing-sm;
-  color: $color-gray-500;
 }
 
 .button {

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -5,6 +5,7 @@
 @import "./variables";
 
 .icon {
+  flex-shrink: 0;
   margin-left: $spacing-sm;
   color: $color-gray-500;
 }


### PR DESCRIPTION
## Why
The Select chevron down/up icon was not taking up the correct 20x20 width. It was instead showing a width of 16.23x20.

## What
**Before**
<img width="561" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/4d5619cb-477a-4ef7-a284-f36c8cba0388">

**After**
<img width="544" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/48f09e90-818a-42f6-a629-055ba2d50a00">
