### PR TITLE
fix(Select): add flex-shrink 0 to MultiSelect TriggerButtonBase so that width is correct

### DIFF
--- a/.changeset/odd-plums-check.md
+++ b/.changeset/odd-plums-check.md
@@ -1,0 +1,7 @@
+---
+"@kaizen/select": patch
+---
+
+fix: add flex-shrink 0 to FilterMultiSelect TriggerButtonBase
+
+the width of the chevron up/down icon was not displaying as 20x20 when a width was applied to the button

--- a/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.module.scss
+++ b/packages/select/src/FilterMultiSelect/components/Trigger/TriggerButtonBase/TriggerButtonBase.module.scss
@@ -10,5 +10,6 @@
 }
 
 .icon {
+  flex-shrink: 0;
   margin-inline-start: $spacing-xs;
 }


### PR DESCRIPTION
## Why
When a width was applied to the button, the icon would shrink and not be displayed as 20x20.


## What
**Before**
<img width="502" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/9714c83f-05ae-48e8-b145-dfaefbb9296f">

**After**
<img width="504" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/935e57e5-c9ce-4b8d-9c86-05accc1daf61">
