### PR TITLE
fix(Select): change margin-left to margin-inline-start

### DIFF
--- a/.changeset/sour-ties-exercise.md
+++ b/.changeset/sour-ties-exercise.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/select": patch
+---
+
+change margin-left to margin-inline-start

--- a/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
+++ b/packages/select/src/Select/components/TriggerButton/TriggerButton.module.scss
@@ -7,7 +7,7 @@
 .icon {
   color: $color-gray-500;
   flex-shrink: 0;
-  margin-left: $spacing-sm;
+  margin-inline-start: $spacing-sm;
 }
 
 .button {


### PR DESCRIPTION
## Why
This PR changes margin-left to margin-inline-start.

In RTL mode the margin was not on the correct side.

## What
**Before**
<img width="259" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/0425179f-06e4-467c-bcc9-064e3a5809eb">

**After**
<img width="239" alt="image" src="https://github.com/cultureamp/kaizen-legacy/assets/1678609/5cfed7eb-ae50-44f9-bc3a-ec8bd268e4c6">

