### PR TITLE
feat(Title Block): Add sentimentPositive to surveyStatus

### DIFF
--- a/.changeset/warm-trains-marry.md
+++ b/.changeset/warm-trains-marry.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/draft-title-block-zen": patch
+---
+
+add sentimentPositive to surveyStatus

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.spec.tsx
@@ -714,6 +714,8 @@ describe("<TitleBlockZen />", () => {
       ["live", "statusLive"],
       ["closed", "statusClosed"],
       ["scheduled", "statusClosed"],
+      ["sentimentPositive", "sentimentPositive"],
+      ["default", "default"],
     ])(
       "renders tag with correct text and variant when %s status",
       async (status, expectedClassName) => {
@@ -727,6 +729,7 @@ describe("<TitleBlockZen />", () => {
                 | "live"
                 | "scheduled"
                 | "closed"
+                | "sentimentPositive"
                 | "default",
             }}
           >

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -205,7 +205,13 @@ type TextDirection = "ltr" | "rtl"
 
 type SurveyStatus = {
   text: string
-  status: "draft" | "live" | "scheduled" | "closed" | "default" | "sentimentPositive"
+  status:
+    | "draft"
+    | "live"
+    | "scheduled"
+    | "closed"
+    | "sentimentPositive"
+    | "default"
 }
 
 const renderTag = (surveyStatus: SurveyStatus): JSX.Element | void => {

--- a/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
+++ b/draft-packages/title-block-zen/KaizenDraft/TitleBlockZen/TitleBlockZen.tsx
@@ -205,7 +205,7 @@ type TextDirection = "ltr" | "rtl"
 
 type SurveyStatus = {
   text: string
-  status: "draft" | "live" | "scheduled" | "closed" | "default"
+  status: "draft" | "live" | "scheduled" | "closed" | "default" | "sentimentPositive"
 }
 
 const renderTag = (surveyStatus: SurveyStatus): JSX.Element | void => {
@@ -236,6 +236,10 @@ const renderTag = (surveyStatus: SurveyStatus): JSX.Element | void => {
 
   if (surveyStatus.status === "closed") {
     tagVariant = "statusClosed"
+  }
+
+  if (surveyStatus.status === "sentimentPositive") {
+    tagVariant = "sentimentPositive"
   }
 
   if (surveyStatus.status === "default") {


### PR DESCRIPTION
## Changes are currently not being accepted due to KAIO Migration.

https://cultureamp.slack.com/archives/C0189KBPM4Y/p1697084415647699

Current design for the rebuild is showing response status in the Title Block, currently the surveyStatus only has options for surveyStatus.

This PR adds a new sentimentPositive options to gives us all the options needed to use the surveyStatus to create the response Status designs
