### PR TITLE
Pass aria-describedby into RTE when sent via props

### DIFF
--- a/.changeset/forty-rats-breathe.md
+++ b/.changeset/forty-rats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@kaizen/rich-text-editor": patch
+---
+
+Pass aria-describedby into RTE when sent via props

--- a/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -66,6 +66,7 @@ export const RichTextEditor = (props: RichTextEditorProps): JSX.Element => {
     defaultValue,
     labelText,
     "aria-labelledby": labelledBy,
+    "aria-describedby": describedBy,
     classNameOverride,
     controls,
     rows = 3,
@@ -128,7 +129,11 @@ export const RichTextEditor = (props: RichTextEditorProps): JSX.Element => {
     : ""
   const descriptionAria = description ? `${editorId}-rte-description` : ""
 
-  const ariaDescribedBy = `${validationMessageAria} ${descriptionAria}`
+  const ariaDescribedBy = classnames(
+    validationMessageAria,
+    descriptionAria,
+    describedBy
+  )
 
   return (
     <>


### PR DESCRIPTION
## Why
RTE currently allows you to pass in aria-describedby but it never gets used.

## What
Pass aria-describedby from props through to the RTE
